### PR TITLE
Fix mixed content error on unit-test module

### DIFF
--- a/src/app/unit-test/unit-test.module.ts
+++ b/src/app/unit-test/unit-test.module.ts
@@ -17,6 +17,6 @@ const routes: Routes = [{ path: '', component: UnitTestComponent }];
 @NgModule({
   declarations: [UnitTestComponent, UppercasePipe],
   imports: [CommonModule, RouterModule.forChild(routes), HttpClientModule, MatInputModule, MatButtonModule, ReactiveFormsModule],
-  providers: [EchoService, EchoTooService, { provide: ECHO_URL, useValue: 'http://httpbin.org/post' }]
+  providers: [EchoService, EchoTooService, { provide: ECHO_URL, useValue: 'https://httpbin.org/post' }]
 })
 export class UnitTestModule {}


### PR DESCRIPTION
Use https instead of http for httpbin endpoint.
Browsers prevent making unsecure calls if the page is loaded under https